### PR TITLE
正規表現に対応した

### DIFF
--- a/server/model/traqMessage.go
+++ b/server/model/traqMessage.go
@@ -95,13 +95,14 @@ func FindMatchingWords(messageList MessageList) ([]*NotifyInfo, error) {
 				users.traq_uuid AS traq_uuid
 			FROM words
 			JOIN users ON words.trap_id = users.trap_id
-				WHERE ? LIKE concat('%', word, '%')
+				WHERE ((word NOT LIKE '/%/') AND (? LIKE concat('%', word, '%')))
+            		OR ((word LIKE '/%/') AND (? REGEXP trim(BOTH '/' FROM word)))
 				AND (me_notification OR
 					 users.traq_uuid != ?)
 				AND (bot_notification OR
 					 (SELECT is_bot FROM users WHERE traq_uuid = ? LIMIT 1) = FALSE)
 			GROUP BY words.trap_id`,
-			messageItem.Content, messageItem.TraqUuid, messageItem.TraqUuid)
+			messageItem.Content, messageItem.Content, messageItem.TraqUuid, messageItem.TraqUuid)
 		if err != nil {
 			slog.Error(fmt.Sprintf("failed to search words with message: `%s`", messageItem.Id))
 			return nil, err

--- a/server/model/traqMessage.go
+++ b/server/model/traqMessage.go
@@ -96,7 +96,7 @@ func FindMatchingWords(messageList MessageList) ([]*NotifyInfo, error) {
 			FROM words
 			JOIN users ON words.trap_id = users.trap_id
 				WHERE ((word NOT LIKE '/%/') AND (? LIKE concat('%', word, '%')))
-            		OR ((word LIKE '/%/') AND (? REGEXP trim(BOTH '/' FROM word)))
+            		OR ((word LIKE '/%/') AND (BINARY ? REGEXP trim(BOTH '/' FROM word)))
 				AND (me_notification OR
 					 users.traq_uuid != ?)
 				AND (bot_notification OR


### PR DESCRIPTION
`/a.+/`のような、`/`で囲まれた登録単語を正規表現として解釈するようにした
`/a.+/`は正規表現記述`a+`として扱われ、`apple`などがマッチする

正規表現の一致判定にはMariaDBの関数[REGEXP](https://mariadb.com/kb/en/regexp/)を使用している
対応している正規表現記法は[Regular Expressions Overview - MariaDB Knowledge Base](https://mariadb.com/kb/en/regular-expressions-overview/)を参照