### PR TITLE
ボタンをガチャガチャしなくとも、ボタンでの値が反映されるようになっているはず

### DIFF
--- a/client/src/components/BotNotify.vue
+++ b/client/src/components/BotNotify.vue
@@ -6,7 +6,15 @@ const emit = defineEmits<{
   (e: 'updateBotNotify', value: boolean): boolean
 }>()
 
-const newBotNotify = ref(true)
+const newBotNotify = ref<boolean>(true)
+
+const props = defineProps<{
+  botNotify: boolean
+}>()
+
+watch(props, () => {
+  newBotNotify.value = props.botNotify
+})
 
 watch(newBotNotify, () => {
   emit('updateBotNotify', newBotNotify.value)

--- a/client/src/components/SelfNotify.vue
+++ b/client/src/components/SelfNotify.vue
@@ -8,6 +8,14 @@ const emit = defineEmits<{
 
 const newSelfNotify = ref(false)
 
+const props = defineProps<{
+  selfNotify: boolean
+}>()
+
+watch(props, () => {
+  newSelfNotify.value = props.selfNotify
+})
+
 watch(newSelfNotify, () => {
   emit('updateSelfNotify', newSelfNotify.value)
 })

--- a/client/src/pages/WordAdd.vue
+++ b/client/src/pages/WordAdd.vue
@@ -85,8 +85,14 @@ const updateNewSelfNotify = (newValue: boolean) => {
     </label>
   </div>
   <div class="flex justify-around my-4">
-    <BotNotify @update-bot-notify="(newValue: boolean) => updateNewBotNotify(newValue)" />
-    <SelfNotify @update-self-notify="(newValue: boolean) => updateNewSelfNotify(newValue)" />
+    <BotNotify
+      @update-bot-notify="(newValue: boolean) => updateNewBotNotify(newValue)"
+      :bot-notify="newBotNotify"
+    />
+    <SelfNotify
+      @update-self-notify="(newValue: boolean) => updateNewSelfNotify(newValue)"
+      :self-notify="newSelfNotify"
+    />
   </div>
   <div class="registerButton mb-16 mt-4">
     <v-btn :disabled="newWord === ''" @click="registerNewWord">登録</v-btn>

--- a/client/src/pages/WordList.vue
+++ b/client/src/pages/WordList.vue
@@ -243,9 +243,11 @@ const updateNewSelfNotify = (newValue: boolean) => {
                 <div class="flex justify-around my-4">
                   <BotNotify
                     @update-bot-notify="(newValue: boolean) => updateNewBotNotify(newValue)"
+                    :bot-notify="edittingIncludeBot"
                   />
                   <SelfNotify
                     @update-self-notify="(newValue :boolean) => updateNewSelfNotify(newValue)"
+                    :self-notify="edittingIncludeMe"
                   />
                 </div>
                 <div class="mt-4">


### PR DESCRIPTION
ボタンをガチャガチャしないとbool方の値が初期状態から変更されずに動作がおかしくなっていたのを修正できたはず