### PR TITLE
メッセージのポーリング取得を漏らさず行うようにした

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -30,9 +30,8 @@ func main() {
 		slog.Info("Error setting up: %v", err)
 	}
 
-	go func() {
-		traqmessage.PollingMessages()
-	}()
+	messagePoller := traqmessage.NewMessagePoller()
+	go messagePoller.Run()
 
 	instance.Logger.Fatal(instance.Start(":8080"))
 }

--- a/server/traqmessage/collect.go
+++ b/server/traqmessage/collect.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"h23s_15/model"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/traPtitech/go-traq"
@@ -30,9 +31,12 @@ func (m *MessagePoller) Run() {
 	pollingInterval := time.Minute * 3
 
 	lastCheckpoint := time.Now()
-	ticker := time.Tick(pollingInterval)
+	var checkpointMutex sync.Mutex
 
+	ticker := time.Tick(pollingInterval)
 	for range ticker {
+		checkpointMutex.Lock()
+
 		now := time.Now()
 		var collectedMessageCount int64
 		for i := 0; ; i++ {
@@ -55,6 +59,7 @@ func (m *MessagePoller) Run() {
 		slog.Info(fmt.Sprintf("Collect %d messages", collectedMessageCount))
 
 		lastCheckpoint = now
+		checkpointMutex.Unlock()
 	}
 }
 


### PR DESCRIPTION
もともと、3分に1回「**最後に取得処理をした時刻以降に投稿された**max100件を取得する」ような実装だった
それを、ちゃんとoffsetを使用して漏らさず取得をかけるようにした

ポーリング開始のトリガーは継続で3分ごとだが、traQの流量が多いとメッセージ取得APIのリクエスト回数が急増する可能性があるので様子を見る