### PR TITLE
メッセージの取得でエラーが発生したときはループを抜けるようにした

### DIFF
--- a/server/traqmessage/collect.go
+++ b/server/traqmessage/collect.go
@@ -44,7 +44,7 @@ func (m *MessagePoller) Run() {
 			messages, err := collectMessages(lastCheckpoint, now, i)
 			if err != nil {
 				slog.Error(fmt.Sprintf("Failled to polling messages: %v", err))
-				continue
+				break
 			}
 
 			slog.Info(fmt.Sprintf("Collect %d messages", messages.TotalHits))


### PR DESCRIPTION
traQからのAPIで404などが帰ってきたときに無限に再リクエストする状態に陥っていたので