### PR TITLE
collationエラーの解消

### DIFF
--- a/server/model/db.go
+++ b/server/model/db.go
@@ -17,7 +17,7 @@ var (
 )
 
 func SetUp() error {
-	_db, err := sqlx.Connect("mysql", fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8&parseTime=True&loc=Local", os.Getenv("DB_USERNAME"), os.Getenv("DB_PASSWORD"), os.Getenv("DB_HOSTNAME"), os.Getenv("DB_PORT"), os.Getenv("DB_DATABASE")))
+	_db, err := sqlx.Connect("mysql", fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local", os.Getenv("DB_USERNAME"), os.Getenv("DB_PASSWORD"), os.Getenv("DB_HOSTNAME"), os.Getenv("DB_PORT"), os.Getenv("DB_DATABASE")))
 	if err != nil {
 		slog.Info("Cannot Connect to Database: %s", err)
 	}


### PR DESCRIPTION
sqlxでのDB接続時において`charset=utf8`から`charset=utf8mb4`にクエリを変更することにより、絵文字をポーリングした際のcollationエラーを回避できるようにしました