### PR TITLE
ログ出力の際にindex out of rangeが発生してパニックするのを回避した

### DIFF
--- a/server/traqmessage/collect.go
+++ b/server/traqmessage/collect.go
@@ -69,7 +69,11 @@ func (m *MessagePoller) Run() {
 			// 取得したメッセージを使っての処理の呼び出し
 			m.processor.enqueue(messages)
 			if !more {
-				slog.Info(fmt.Sprintf("The first one is created at %v.", (*messages)[tmpMessageCount-1].CreatedAt))
+				if tmpMessageCount <= 0 {
+					slog.Info("Message count is 0. Skip logging created at information")
+				} else {
+					slog.Info(fmt.Sprintf("The first one is created at %v.", (*messages)[tmpMessageCount-1].CreatedAt))
+				}
 				break
 			}
 		}


### PR DESCRIPTION
パニックと再起動の繰り返しのログ

```
3/3/2024, 6:54:05 AM 2024/03/02 21:54:05 INFO Connected to Database
3/3/2024, 6:54:05 AM
3/3/2024, 6:54:05 AM ____ __
3/3/2024, 6:54:05 AM / __/___/ / ___
3/3/2024, 6:54:05 AM / _// __/ _ \/ _ \
3/3/2024, 6:54:05 AM /___/\__/_//_/\___/ v4.10.2
3/3/2024, 6:54:05 AM High performance, minimalist Go web framework
3/3/2024, 6:54:05 AM https://echo.labstack.com
3/3/2024, 6:54:05 AM ____________________________________O/_______
3/3/2024, 6:54:05 AM O\
3/3/2024, 6:54:05 AM ⇨ http server started on [::]:8080
3/3/2024, 6:57:05 AM 2024/03/02 21:57:05 INFO Start polling
3/3/2024, 6:57:06 AM 2024/03/02 21:57:06 INFO Collected 100 messages
3/3/2024, 6:57:06 AM 2024/03/02 21:57:06 INFO Collected 0 messages
3/3/2024, 6:57:06 AM 2024/03/02 21:57:06 INFO Sending 36 DMs...
3/3/2024, 6:57:06 AM 2024/03/02 21:57:06 INFO End of send DMs
3/3/2024, 6:57:06 AM 2024/03/02 21:57:06 INFO Sending 0 DMs...
3/3/2024, 6:57:06 AM 2024/03/02 21:57:06 INFO End of send DMs
3/3/2024, 6:57:06 AM panic: runtime error: index out of range [-1]
3/3/2024, 6:57:06 AM
3/3/2024, 6:57:06 AM goroutine 27 [running]:
3/3/2024, 6:57:06 AM traQ-gazer/traqmessage.(*MessagePoller).Run(0xc000012078)
3/3/2024, 6:57:06 AM /github.com/traP-jp/h23s_15/traqmessage/collect.go:72 +0x5b8
3/3/2024, 6:57:06 AM created by main.main
3/3/2024, 6:57:06 AM /github.com/traP-jp/h23s_15/main.go:35 +0x385
3/3/2024, 7:02:09 AM 2024/03/02 22:02:09 INFO Connected to Database
3/3/2024, 7:02:10 AM
3/3/2024, 7:02:10 AM ____ __
3/3/2024, 7:02:10 AM / __/___/ / ___
3/3/2024, 7:02:10 AM / _// __/ _ \/ _ \
3/3/2024, 7:02:10 AM /___/\__/_//_/\___/ v4.10.2
3/3/2024, 7:02:10 AM High performance, minimalist Go web framework
3/3/2024, 7:02:10 AM https://echo.labstack.com
3/3/2024, 7:02:10 AM ____________________________________O/_______
3/3/2024, 7:02:10 AM O\
3/3/2024, 7:02:10 AM ⇨ http server started on [::]:8080
3/3/2024, 7:05:10 AM 2024/03/02 22:05:10 INFO Start polling
3/3/2024, 7:05:10 AM 2024/03/02 22:05:10 INFO Collected 100 messages
3/3/2024, 7:05:10 AM 2024/03/02 22:05:10 INFO Collected 0 messages
3/3/2024, 7:05:10 AM 2024/03/02 22:05:10 INFO Sending 41 DMs...
3/3/2024, 7:05:11 AM 2024/03/02 22:05:11 INFO End of send DMs
3/3/2024, 7:05:11 AM panic: runtime error: index out of range [-1]
3/3/2024, 7:05:11 AM
3/3/2024, 7:05:11 AM goroutine 41 [running]:
3/3/2024, 7:05:11 AM traQ-gazer/traqmessage.(*MessagePoller).Run(0xc000012120)
3/3/2024, 7:05:11 AM /github.com/traP-jp/h23s_15/traqmessage/collect.go:72 +0x5b8
3/3/2024, 7:05:11 AM created by main.main
3/3/2024, 7:05:11 AM /github.com/traP-jp/h23s_15/main.go:35 +0x385
3/3/2024, 7:10:24 AM 2024/03/02 22:10:24 INFO Connected to Database
3/3/2024, 7:10:24 AM
3/3/2024, 7:10:24 AM ____ __
3/3/2024, 7:10:24 AM / __/___/ / ___
3/3/2024, 7:10:24 AM / _// __/ _ \/ _ \
3/3/2024, 7:10:24 AM /___/\__/_//_/\___/ v4.10.2
3/3/2024, 7:10:24 AM High performance, minimalist Go web framework
3/3/2024, 7:10:24 AM https://echo.labstack.com
3/3/2024, 7:10:24 AM ____________________________________O/_______
3/3/2024, 7:10:24 AM O\
3/3/2024, 7:10:24 AM ⇨ http server started on [::]:8080
```