### PR TITLE
Delete prism dockerfile

### DIFF
--- a/dockerfiles/prism.Dockerfile
+++ b/dockerfiles/prism.Dockerfile
@@ -1,3 +1,0 @@
-FROM stoplight/prism:4.11.0
-
-COPY docs/openapi.yaml /tmp/openapi.yaml


### PR DESCRIPTION
because of adding node packafe `@stoplight/prism-cli`, the dockerfile for prism is no longer needed