### PR TITLE
💄 行の背景色を交互に切り替えて見やすくする

### DIFF
--- a/client/src/components/WordList.vue
+++ b/client/src/components/WordList.vue
@@ -37,6 +37,9 @@ const update = () => {
   border-collapse: collapse;
   border-spacing: 8px;
 }
+tbody > tr:nth-child(2n){
+  background: $secondary-background-color-dark;
+}
 th {
   padding: 0px 8px;
   border-bottom: 1px solid $text-color;

--- a/client/src/components/WordList.vue
+++ b/client/src/components/WordList.vue
@@ -37,7 +37,7 @@ const update = () => {
   border-collapse: collapse;
   border-spacing: 8px;
 }
-tbody > tr:nth-child(2n){
+tbody > tr:nth-child(2n) {
   background: $secondary-background-color-dark;
 }
 th {

--- a/client/src/components/WordList.vue
+++ b/client/src/components/WordList.vue
@@ -38,7 +38,10 @@ const update = () => {
   border-spacing: 8px;
 }
 tbody > tr:nth-child(2n) {
-  background: $secondary-background-color-dark;
+  background: $secondary-background-color;
+  @include dark {
+    background: $secondary-background-color-dark;
+  }
 }
 th {
   padding: 0px 8px;


### PR DESCRIPTION
メインページのテーブルの行の背景を交互に切り替えて見やすくした.

![image](https://github.com/user-attachments/assets/985265b2-8398-429c-8a3f-eb4a938fcc75)
